### PR TITLE
Fix e2e cleanup failing on noble-24.04 stack

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -18,7 +18,10 @@ workflows:
         inputs:
         - content: |-
             set -ex
-            rm -rf ~/.gradle
+            # Skip ~/.gradle/init.d — populated by the Bitrise stack image and
+            # held open on the noble-24.04 docker stack, which causes
+            # `rm -rf ~/.gradle` to fail with "Device or resource busy".
+            find ~/.gradle -mindepth 1 -maxdepth 1 ! -name init.d -exec rm -rf {} +
             rm -rf ./_tmp/.gradle
     - android-build:
         inputs:
@@ -40,7 +43,10 @@ workflows:
         inputs:
         - content: |-
               set -ex
-              rm -rf ~/.gradle
+              # Skip ~/.gradle/init.d — populated by the Bitrise stack image and
+              # held open on the noble-24.04 docker stack, which causes
+              # `rm -rf ~/.gradle` to fail with "Device or resource busy".
+              find ~/.gradle -mindepth 1 -maxdepth 1 ! -name init.d -exec rm -rf {} +
               rm -rf ./_tmp/.gradle
     - path::./:
         title: Execute step

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -43,6 +43,8 @@ workflows:
         inputs:
         - content: |-
               set -ex
+              # Stop the daemon so it doesn't race with the cleanup below.
+              ./gradlew -stop || true
               # Skip ~/.gradle/init.d — populated by the Bitrise stack image and
               # held open on the noble-24.04 docker stack, which causes
               # `rm -rf ~/.gradle` to fail with "Device or resource busy".


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] \`step.yml\` and \`README.md\` is updated with the changes (if needed)

### Version

No version bump — e2e workflow change only, step is not affected.

### Context

CI is blocked on the \`ubuntu-noble-24.04-bitrise-2025-android\` matrix slot for #10 (and other PRs):

\`\`\`
rm: cannot remove '/root/.gradle/init.d': Device or resource busy
exit status 1
\`\`\`

The noble-24.04 docker image populates \`/root/.gradle/init.d\` with stack-provided init scripts and holds them open, so the cleanup blocks in \`e2e/bitrise.yml\` fail when they try to remove the whole \`~/.gradle\` directory. The older \`linux-docker-android-22.04\` image didn't do this, so the test workflow was fine there.

### Changes

Replace \`rm -rf ~/.gradle\` with a \`find\` that skips \`init.d\` in both cleanup blocks (\`test_full\` workflow, before-save and before-restore). The cleanup still removes everything Gradle generates between runs (\`caches\`, \`wrapper\`, etc.), which is what the tests actually depend on.

Sibling fix: bitrise-steplib/bitrise-step-save-gradle-cache#33